### PR TITLE
node-gyp is unnecessary here

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "blowfish",
     "hash"
   ],
-  "dependencies":{
-    "node-gyp": "*"
-  },
   "author": "Jaakko-Heikki Heusala <jheusala@iki.fi>",
   "license": "MIT",
   "gypfile": true


### PR DESCRIPTION
`npm` can build the module without `node-gyp` present as a dependency just fine because it has `node-gyp` built-in.

Specifying it as a dependency just causes extra 11 megabytes to be installed which aren't used anywhere.
