### PR TITLE
add node 0.11 compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     {
       "target_name": "crypt3",
       "sources": [ "crypt3.cc" ],
+      "include_dirs" : [ "<!(node -e \"require('nan')\")" ],
       "conditions": [
         ['OS!="mac"', {
           'link_settings': { "libraries": [ "-lcrypt" ] }

--- a/crypt3.cc
+++ b/crypt3.cc
@@ -4,20 +4,19 @@
 #include <v8.h>
 #include <errno.h>
 #include <unistd.h>		// for crypt if _XOPEN_SOURCE exists
+#include <nan.h>
 
 using namespace v8;
 
-Handle<Value> Method(const Arguments& args) {
-	HandleScope scope;
+NAN_METHOD(Method) {
+	NanScope();
 
 	if (args.Length() < 2) {
-		ThrowException(Exception::TypeError(String::New("Wrong number of arguments")));
-		return scope.Close(Undefined());
+		return NanThrowTypeError("Wrong number of arguments");
 	}
 
 	if (!args[0]->IsString() || !args[1]->IsString()) {
-		ThrowException(Exception::TypeError(String::New("Wrong arguments")));
-		return scope.Close(Undefined());
+		return NanThrowTypeError("Wrong arguments");
 	}
 
 	v8::String::Utf8Value key(args[0]->ToString());
@@ -25,14 +24,14 @@ Handle<Value> Method(const Arguments& args) {
 
 	char* res = crypt(*key, *salt);
 	if (res != NULL) {
-		return scope.Close(String::New(res));
+		NanReturnValue(NanNew<String>(res));
 	} else {
-		return ThrowException(node::ErrnoException(errno, "crypt"));
+		return NanThrowError(node::ErrnoException(errno, "crypt"));
 	}
 }
 
 void init(Handle<Object> exports) {
-	exports->Set(String::NewSymbol("crypt"), FunctionTemplate::New(Method)->GetFunction());
+	exports->Set(NanNew<String>("crypt"), NanNew<FunctionTemplate>(Method)->GetFunction());
 }
 
 NODE_MODULE(crypt3, init)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js crypt(3) bindings",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/test.js",
     "install": "node-gyp rebuild"
   },
   "repository": {
@@ -20,6 +20,7 @@
     "blowfish",
     "hash"
   ],
+  "dependencies": { "nan": "~1.3.0" },
   "author": "Jaakko-Heikki Heusala <jheusala@iki.fi>",
   "license": "MIT",
   "gypfile": true

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,14 @@
+var assert = require('assert')
+var crypt3 = require('../')
+
+assert.throws(function() {
+	crypt3()
+}, /Wrong arguments/)
+
+assert.equal(crypt3('pass', 'salt'), 'sa5JEXtYx/rm6')
+assert.equal(crypt3('pass', 'sa5JEXtYx/rm6'), 'sa5JEXtYx/rm6')
+
+var hash = crypt3('password')
+assert.equal(crypt3('password', hash), hash)
+assert.notEqual(crypt3('bad-pass', hash), hash)
+


### PR DESCRIPTION
Currently node 0.11 can't compile this, because they changed interfaces:

```
/home/alex/.node-gyp/0.11.13/deps/v8/include/v8.h: In function ‘v8::Handle<v8::Value> Method(const int&)’:
/home/alex/.node-gyp/0.11.13/deps/v8/include/v8.h:845:13: error: ‘v8::HandleScope::HandleScope()’ is protected
   V8_INLINE HandleScope() {}
             ^
../crypt3.cc:11:14: error: within this context
  HandleScope scope;
              ^
../crypt3.cc:13:11: error: request for member ‘Length’ in ‘args’, which is of non-class type ‘const int’
  if (args.Length() < 2) {
           ^
../crypt3.cc:14:39: error: ‘New’ is not a member of ‘v8::String’
   ThrowException(Exception::TypeError(String::New("Wrong number of arguments")));
```

This patch should fix this, I tested on both `0.11.13` and `0.10.31`.

I'm using `nan` module for this, because manually supporting both versions looks too complex.

Also, added smoke tests, so you could this check automated with travis or something like that.
