### PR TITLE
update nan dependency to 1.6.2+

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "blowfish",
     "hash"
   ],
-  "dependencies": { "nan": "~1.3.0" },
+  "dependencies": { "nan": "1 >=1.6.2" },
   "author": "Jaakko-Heikki Heusala <jheusala@iki.fi>",
   "license": "MIT",
   "gypfile": true


### PR DESCRIPTION
This is necessary to compile crypt3 under io.js (see details in https://github.com/rvagg/nan/pull/224).